### PR TITLE
Fix import path for bitcask

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ibbd-dev/go-csv v0.0.0-20180710072442-95221cf028d5 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/mattn/go-colorable v0.1.6 // indirect
-	github.com/prologic/bitcask v0.3.5
+	git.mills.io/prologic/bitcask v0.3.5
 	go.mongodb.org/mongo-driver v1.3.1 // indirect
 	golang.org/x/tools v0.0.0-20200606014950-c42cb6316fb6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/plar/go-adaptive-radix-tree v1.0.1 h1:J+2qrXaKWLACw59s8SlTVYYxWjlUr/BlCsfkAzn96/0=
 github.com/plar/go-adaptive-radix-tree v1.0.1/go.mod h1:Ot8d28EII3i7Lv4PSvBlF8ejiD/CtRYDuPsySJbSaK8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prologic/bitcask v0.3.5 h1:o5PekS/LTRXQvLmY/5oQxIgjdT5bwcxPLsrGmnyo3Yo=
-github.com/prologic/bitcask v0.3.5/go.mod h1:gl5FAhs5GhvmV6tEIQWwk9d/FD9vc8NC8Hs24/zU/4w=
+git.mills.io/prologic/bitcask v0.3.5 h1:o5PekS/LTRXQvLmY/5oQxIgjdT5bwcxPLsrGmnyo3Yo=
+git.mills.io/prologic/bitcask v0.3.5/go.mod h1:gl5FAhs5GhvmV6tEIQWwk9d/FD9vc8NC8Hs24/zU/4w=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/server/database/preprocessing/BuildDb.go
+++ b/server/database/preprocessing/BuildDb.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	. "github.com/b-esc/carolyns-web/server/models"
 	"github.com/k0kubun/pp"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"io"
 	"log"
 	"os"

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -14,7 +14,7 @@ import (
 	"github.com/deckarep/golang-set"
 	"github.com/gorilla/mux" // routing
 	//"github.com/k0kubun/pp"
-	. "github.com/prologic/bitcask"
+	. "git.mills.io/prologic/bitcask"
 	"log"
 	"net/http"
 	"path/filepath"

--- a/server/middleware/utils_go.old
+++ b/server/middleware/utils_go.old
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	. "github.com/b-esc/carolyns-web/server/models"
 	"github.com/k0kubun/pp"
-	. "github.com/prologic/bitcask"
+	. "git.mills.io/prologic/bitcask"
 	"log"
 	"path/filepath"
 	"sort"


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇